### PR TITLE
Remove navigation menu from site header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,5 @@
+<header class="site-header" role="banner">
+  <div class="wrapper">
+    <a class="site-title" rel="author" href="{{ '/' | relative_url }}">{{ site.title | escape }}</a>
+  </div>
+</header>


### PR DESCRIPTION
## Summary
- override the Minima header include to remove the navigation menu from the site header

## Testing
- bundle exec jekyll build *(fails: jekyll executable is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9989d6ea883338457655ef323b9ed